### PR TITLE
DM-26497: update for ts_salobj 6.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-matrix:
-  include:
-    - python: '3.6'
-      install:
-        - 'pip install flake8'
-      script:
-        - flake8

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,24 @@
 Version History
 ###############
 
+v1.4.0
+======
+
+Changes:
+
+* Update for ts_salobj 6.1, which is required.
+* Add `WatcherCsc` constructor argument ``settings_to_apply`` and set class variable ``require_settings = True``.
+* Fix deprecation warnings about calling get(flush=False) on read topics.
+* Remove obsolete .travis.yml file.
+
+Requires:
+
+* ts_salobj 6.1
+* ts_xml 4.6 - 6
+* ts_idl 2
+* IDL files for ``Watcher``, ``ATDome``, ``ScriptQueue``, and ``Test``, plus any SAL components you wish to watch.
+  These may be generated using ``make_idl_files.py``
+
 v1.3.3
 ======
 
@@ -21,7 +39,6 @@ Requires:
 * ts_idl 2
 * IDL files for ``Watcher``, ``ATDome``, ``ScriptQueue``, and ``Test``, plus any SAL components you wish to watch.
   These may be generated using ``make_idl_files.py``
-
 
 v1.3.2
 ======

--- a/python/lsst/ts/watcher/base/remote_wrapper.py
+++ b/python/lsst/ts/watcher/base/remote_wrapper.py
@@ -30,7 +30,7 @@ class RemoteWrapper:
     The wrapper uses the same attribute names as `lsst.ts.salobj.Remote`,
     but the wrapper's attributes return the current value of the topic.
     For example `remote_wrapper.evt_summaryState` returns
-    `remote.evt_summaryState.get(flush=False)`.
+    `remote.evt_summaryState.get()`.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ class RemoteWrapper:
         RuntimeError
             If the Remote has not started.
         """
-        return self._topics[name].get(flush=False)
+        return self._topics[name].get()
 
     def __dir__(self):
         return dir(RemoteWrapper) + list(self._topics.keys())

--- a/python/lsst/ts/watcher/base/topic_callback.py
+++ b/python/lsst/ts/watcher/base/topic_callback.py
@@ -80,7 +80,7 @@ class TopicCallback:
         This is provided so that code in `Rule.__call__` can easily get
         the current value of the topic that triggered the call.
         """
-        return self._topic.get(flush=False)
+        return self._topic.get()
 
     def __call__(self, value):
         if not self.model.enabled:

--- a/python/lsst/ts/watcher/model.py
+++ b/python/lsst/ts/watcher/model.py
@@ -163,7 +163,7 @@ class Model:
             rule.alarm.reset()
             rule.start()
         for topic in self._topics_with_callbacks:
-            data = topic.get(flush=False)
+            data = topic.get()
             if data is not None:
                 callback_coros.append(topic._run_callback(data))
         self.enable_task = asyncio.ensure_future(asyncio.gather(*callback_coros))

--- a/python/lsst/ts/watcher/watcher_csc.py
+++ b/python/lsst/ts/watcher/watcher_csc.py
@@ -43,6 +43,10 @@ class WatcherCsc(salobj.ConfigurableCsc):
         The initial state of the CSC. This is provided for unit testing,
         as real CSCs should start up in `lsst.ts.salobj.StateSTANDBY`,
         the default.
+    settings_to_apply : `str`, optional
+        Settings to apply if ``initial_state`` is `State.DISABLED`
+        or `State.ENABLED` (in which case a non-empty value is required
+        for this CSC).
 
     Raises
     ------
@@ -51,8 +55,12 @@ class WatcherCsc(salobj.ConfigurableCsc):
     """
 
     valid_simulation_modes = [0]
+    enable_cmdline_state = True
+    require_settings = True
 
-    def __init__(self, config_dir=None, initial_state=salobj.State.STANDBY):
+    def __init__(
+        self, config_dir=None, initial_state=salobj.State.STANDBY, settings_to_apply=""
+    ):
         schema_path = (
             pathlib.Path(__file__)
             .resolve()
@@ -68,6 +76,7 @@ class WatcherCsc(salobj.ConfigurableCsc):
             schema_path=schema_path,
             config_dir=config_dir,
             initial_state=initial_state,
+            settings_to_apply=settings_to_apply,
         )
 
     @staticmethod

--- a/tests/base/test_remote_wrapper.py
+++ b/tests/base/test_remote_wrapper.py
@@ -35,7 +35,7 @@ index_gen = salobj.index_generator()
 
 class RemoteWrapperTestCase(asynctest.TestCase):
     def setUp(self):
-        salobj.set_random_lsst_dds_domain()
+        salobj.set_random_lsst_dds_partition_prefix()
         self.index = next(index_gen)
 
     async def test_all_names(self):

--- a/tests/base/test_topic_callback.py
+++ b/tests/base/test_topic_callback.py
@@ -42,7 +42,7 @@ class MockModel:
 
 class TopicCallbackTestCase(asynctest.TestCase):
     def setUp(self):
-        salobj.set_random_lsst_dds_domain()
+        salobj.set_random_lsst_dds_partition_prefix()
         self.index = next(index_gen)
 
     def make_enabled_rule(self):

--- a/tests/rules/test_clock.py
+++ b/tests/rules/test_clock.py
@@ -59,7 +59,7 @@ class HeartbeatWriter(salobj.topics.ControllerEvent):
 
 class ClockTestCase(asynctest.TestCase):
     def setUp(self):
-        salobj.set_random_lsst_dds_domain()
+        salobj.set_random_lsst_dds_partition_prefix()
 
     def make_config(self, name, threshold):
         """Make a config for the Clock rule.

--- a/tests/rules/test_enabled.py
+++ b/tests/rules/test_enabled.py
@@ -35,7 +35,7 @@ LONG_TIMEOUT = 60  # timeout for starting all watcher remotes (sec)
 
 class EnabledTestCase(asynctest.TestCase):
     def setUp(self):
-        salobj.set_random_lsst_dds_domain()
+        salobj.set_random_lsst_dds_partition_prefix()
 
     def make_config(self, name):
         """Make a config for the Enabled rule.

--- a/tests/rules/test_heartbeat.py
+++ b/tests/rules/test_heartbeat.py
@@ -35,7 +35,7 @@ LONG_TIMEOUT = 60  # timeout for starting all watcher remotes (sec)
 
 class HeartbeatTestCase(asynctest.TestCase):
     def setUp(self):
-        salobj.set_random_lsst_dds_domain()
+        salobj.set_random_lsst_dds_partition_prefix()
 
     def make_config(self, name, timeout):
         """Make a config for the Heartbeat rule.

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -22,6 +22,7 @@ import asyncio
 import glob
 import os
 import pathlib
+import sys
 import unittest
 
 import asynctest
@@ -572,6 +573,19 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
             # There should be the only alarm event from the unmute command.
             with self.assertRaises(asyncio.TimeoutError):
                 await self.remote.evt_alarm.next(flush=False, timeout=1)
+
+    async def test_settings_required(self):
+        """Test that the command line parser requires --settings
+        if --state is enabled or disabled.
+        """
+        original_argv = sys.argv[:]
+        try:
+            for state_name in ("disabled", "enabled"):
+                sys.argv = [original_argv[0], "run_watcher.py", "--state", state_name]
+                with self.assertRaises(SystemExit):
+                    await watcher.WatcherCsc.make_from_cmd_line(index=None)
+        finally:
+            sys.argv = original_argv
 
     async def test_unacknowledge(self):
         """Test the unacknowledge command."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -58,7 +58,7 @@ class GetRuleClassTestCase(unittest.TestCase):
 
 class ModelTestCase(asynctest.TestCase):
     def setUp(self):
-        salobj.set_random_lsst_dds_domain()
+        salobj.set_random_lsst_dds_partition_prefix()
 
     @contextlib.asynccontextmanager
     async def make_model(self, names, enable, escalation=()):


### PR DESCRIPTION
Note that the previous version is also compatible with ts_salobj 6.1, but the command line parser will lie to you by claiming to support `--state`, which will fail because Watcher needs a non-blank settingsToApply.