### PR TITLE
DM-41544: Watcher continues to raise alarms of restarted components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ python/lsst/ts/watcher/version.py
 .flake8
 .isort.cfg
 .mypy.ini
+.clang-format
+.ruff.toml
+towncrier.toml

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,20 @@
 Version History
 ###############
 
+v1.17.2
+-------
+
+* Update heartbeat tests to raise an exception when there are errors, and fix them to capture the correct behavior of the rule.
+* Update unit tests to be more reliable when running with the kafka version of salobj.
+* In ``watcher_csc.py``, pass logger when instantiating the model.
+* In ``model.py``, add logger to the ``Model`` class and pass in logger when creating rules.
+* In ``base_rule.py``, add logger to ``BaseRule`` class and pass logger to ``Alarm`` class when instantiating it.
+* In ``base_ess_rule.py``, add logger to ``BaseESSRule``.
+* Add logger to all rules.
+* In ``alarm.py``, add logger to ``Alarm`` class.
+* In ``rules/heartbeat.py``, use ``_get_publish_severity_reason`` when setting alarm severity in ``heartbeat_timer`` to make sure it keeps track of the alarm state.
+* Update .gitignore with latest ts-pre-commit-config setup.
+
 v1.17.1
 -------
 

--- a/python/lsst/ts/watcher/alarm.py
+++ b/python/lsst/ts/watcher/alarm.py
@@ -23,6 +23,7 @@ __all__ = ["Alarm"]
 
 import asyncio
 import inspect
+import logging
 
 from lsst.ts import utils
 from lsst.ts.idl.enums.Watcher import AlarmSeverity
@@ -40,6 +41,8 @@ class Alarm:
         Name of alarm. This must be unique among all alarms
         and should be of the form system.[subsystem....]_name
         so that groups of related alarms can be acknowledged.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Attributes
     ----------
@@ -102,8 +105,13 @@ class Alarm:
         )
     )
 
-    def __init__(self, name):
+    def __init__(self, name, log=None):
         self.name = name
+        self.log = (
+            logging.getLogger(type(self).__name__)
+            if log is None
+            else log.getChild(type(self).__name__)
+        )
         self._callback = None
         self.auto_acknowledge_delay = 0
         self.auto_unacknowledge_delay = 0

--- a/python/lsst/ts/watcher/base_ess_rule.py
+++ b/python/lsst/ts/watcher/base_ess_rule.py
@@ -104,7 +104,8 @@ class BaseEssRule(PollingRule):
     value_format : `str`, optional
         Format for float value (threshold level or measured value)
         without a leading colon, e.g. "0.2f"
-
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Attributes
     ----------
@@ -137,6 +138,7 @@ class BaseEssRule(PollingRule):
         is_indexed,
         units,
         value_format="0.2f",
+        log=None,
     ):
         self.topic_attr_name = topic_attr_name
         self.field_name = field_name
@@ -187,6 +189,7 @@ class BaseEssRule(PollingRule):
             config=config,
             name=name,
             remote_info_list=remote_info_list,
+            log=log,
         )
 
     def setup(self, model):

--- a/python/lsst/ts/watcher/polling_rule.py
+++ b/python/lsst/ts/watcher/polling_rule.py
@@ -46,6 +46,8 @@ class PollingRule(BaseRule):
         so that groups of related alarms can be acknowledged.
     remote_info_list : `list` [`RemoteInfo`]
         Information about the remotes used by this rule.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Attributes
     ----------
@@ -57,10 +59,12 @@ class PollingRule(BaseRule):
         Task that runs the polling loop.
     """
 
-    def __init__(self, config, name, remote_info_list):
+    def __init__(self, config, name, remote_info_list, log=None):
         self.poll_start_tai = utils.current_tai()
         self.poll_loop_task = utils.make_done_future()
-        super().__init__(config=config, name=name, remote_info_list=remote_info_list)
+        super().__init__(
+            config=config, name=name, remote_info_list=remote_info_list, log=log
+        )
 
     def start(self):
         self.poll_loop_task.cancel()

--- a/python/lsst/ts/watcher/rules/atcamera_dewar.py
+++ b/python/lsst/ts/watcher/rules/atcamera_dewar.py
@@ -71,6 +71,8 @@ class ATCameraDewar(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Raises
     ------
@@ -104,7 +106,7 @@ class ATCameraDewar(watcher.BaseRule):
     median values reported within a configurable time window.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_info = watcher.RemoteInfo(
             name="ATCamera",
             index=0,
@@ -115,6 +117,7 @@ class ATCameraDewar(watcher.BaseRule):
             config=config,
             name="ATCameraDewar",
             remote_info_list=[remote_info],
+            log=log,
         )
         self.data_queue: salobj.BaseDdsDataType = collections.deque()
         self.max_data_age: float = max(config.temperature_window, config.vacuum_window)

--- a/python/lsst/ts/watcher/rules/clock.py
+++ b/python/lsst/ts/watcher/rules/clock.py
@@ -40,6 +40,8 @@ class Clock(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -50,7 +52,7 @@ class Clock(watcher.BaseRule):
     min_errors = 3
     """Number of sequential errors required for a failure"""
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_name, remote_index = salobj.name_to_name_index(config.name)
         remote_info = watcher.RemoteInfo(
             name=remote_name,
@@ -62,6 +64,7 @@ class Clock(watcher.BaseRule):
             config=config,
             name=f"Clock.{remote_info.name}:{remote_info.index}",
             remote_info_list=[remote_info],
+            log=log,
         )
         self.threshold = config.threshold
         # An array of up to `min_errors` recent measurements of clock error

--- a/python/lsst/ts/watcher/rules/dew_point_depression.py
+++ b/python/lsst/ts/watcher/rules/dew_point_depression.py
@@ -43,6 +43,8 @@ class DewPointDepression(watcher.PollingRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -55,7 +57,7 @@ class DewPointDepression(watcher.PollingRule):
     where the data is differentiated by the value of the sensorName field.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         self.poll_start_tai = utils.current_tai()
         self.poll_loop_task = utils.make_done_future()
 
@@ -112,6 +114,7 @@ class DewPointDepression(watcher.PollingRule):
             config=config,
             name=f"DewPointDepression.{config.name}",
             remote_info_list=remote_info_list,
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/rules/enabled.py
+++ b/python/lsst/ts/watcher/rules/enabled.py
@@ -38,6 +38,8 @@ class Enabled(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -45,7 +47,7 @@ class Enabled(watcher.BaseRule):
     where name and index are derived from ``config.name``.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_name, remote_index = salobj.name_to_name_index(config.name)
         remote_info = watcher.RemoteInfo(
             name=remote_name,
@@ -57,6 +59,7 @@ class Enabled(watcher.BaseRule):
             config=config,
             name=f"Enabled.{remote_info.name}:{remote_info.index}",
             remote_info_list=[remote_info],
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/rules/heartbeat.py
+++ b/python/lsst/ts/watcher/rules/heartbeat.py
@@ -39,6 +39,8 @@ class Heartbeat(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -46,7 +48,7 @@ class Heartbeat(watcher.BaseRule):
     where name and index are derived from ``config.name``.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_name, remote_index = salobj.name_to_name_index(config.name)
         remote_info = watcher.RemoteInfo(
             name=remote_name,
@@ -58,6 +60,7 @@ class Heartbeat(watcher.BaseRule):
             config=config,
             name=f"Heartbeat.{remote_info.name}:{remote_info.index}",
             remote_info_list=[remote_info],
+            log=log,
         )
         self.heartbeat_timer_task = utils.make_done_future()
 

--- a/python/lsst/ts/watcher/rules/heartbeat.py
+++ b/python/lsst/ts/watcher/rules/heartbeat.py
@@ -109,10 +109,12 @@ class Heartbeat(watcher.BaseRule):
     async def heartbeat_timer(self):
         """Heartbeat timer."""
         await asyncio.sleep(self.config.timeout)
-        await self.alarm.set_severity(
-            severity=self.config.alarm_severity,
-            reason=f"Heartbeat event not seen in {self.config.timeout} seconds",
+        severity_reason = (
+            self.config.alarm_severity,
+            f"Heartbeat event not seen in {self.config.timeout} seconds",
         )
+        severity, reason = self._get_publish_severity_reason(severity_reason)
+        await self.alarm.set_severity(severity=severity, reason=reason)
 
     def restart_timer(self):
         """Start or restart the heartbeat timer."""

--- a/python/lsst/ts/watcher/rules/humidity.py
+++ b/python/lsst/ts/watcher/rules/humidity.py
@@ -36,6 +36,8 @@ class Humidity(BaseEssRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -48,7 +50,7 @@ class Humidity(BaseEssRule):
     where the data is differentiated by the value of the sensorName field.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         self.poll_loop_task = utils.make_done_future()
 
         super().__init__(
@@ -61,6 +63,7 @@ class Humidity(BaseEssRule):
             big_is_bad=True,
             units="%",
             value_format="0.2f",
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/rules/mt_air_compressors_state.py
+++ b/python/lsst/ts/watcher/rules/mt_air_compressors_state.py
@@ -47,13 +47,15 @@ class MTAirCompressorsState(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
     The alarm name is "MTAirCompressorsState".
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_infos = [
             watcher.RemoteInfo(
                 name="MTAirCompressor",
@@ -69,6 +71,7 @@ class MTAirCompressorsState(watcher.BaseRule):
             config=config,
             name="MTAirCompressorsState",
             remote_info_list=remote_infos,
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/rules/mt_ccw_following_rotator.py
+++ b/python/lsst/ts/watcher/rules/mt_ccw_following_rotator.py
@@ -42,13 +42,15 @@ class MTCCWFollowingRotator(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Ignored, because this rule has no configuration.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
     The alarm name is "MTCCWFollowingRotator".
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_info = watcher.RemoteInfo(
             name="MTMount",
             index=0,
@@ -59,6 +61,7 @@ class MTCCWFollowingRotator(watcher.BaseRule):
             config=config,
             name="MTCCWFollowingRotator",
             remote_info_list=[remote_info],
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/rules/over_temperature.py
+++ b/python/lsst/ts/watcher/rules/over_temperature.py
@@ -35,6 +35,8 @@ class OverTemperature(BaseEssRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -47,7 +49,7 @@ class OverTemperature(BaseEssRule):
     where the data is differentiated by the value of the sensorName field.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         super().__init__(
             config=config,
             name=f"OverTemperature.{config.name}",
@@ -58,6 +60,7 @@ class OverTemperature(BaseEssRule):
             big_is_bad=True,
             units="C",
             value_format="0.2f",
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/rules/script_failed.py
+++ b/python/lsst/ts/watcher/rules/script_failed.py
@@ -44,6 +44,8 @@ class ScriptFailed(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -51,7 +53,7 @@ class ScriptFailed(watcher.BaseRule):
     where index are derived from ``config.index``.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         remote_name = "ScriptQueue"
         remote_index = config.index
         remote_info = watcher.RemoteInfo(
@@ -64,6 +66,7 @@ class ScriptFailed(watcher.BaseRule):
             config=config,
             name=f"ScriptFailed.ScriptQueue:{remote_index}",
             remote_info_list=[remote_info],
+            log=log,
         )
 
         self.queue_running = None

--- a/python/lsst/ts/watcher/rules/test/configured_severities.py
+++ b/python/lsst/ts/watcher/rules/test/configured_severities.py
@@ -35,6 +35,8 @@ class ConfiguredSeverities(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Raises
     ------
@@ -55,11 +57,12 @@ class ConfiguredSeverities(watcher.BaseRule):
     The alarm name is ``f"test.ConfiguredSeverities.{config.name}"``
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         super().__init__(
             config=config,
             name=f"test.ConfiguredSeverities.{config.name}",
             remote_info_list=[],
+            log=log,
         )
         self.run_task = utils.make_done_future()
 

--- a/python/lsst/ts/watcher/rules/test/no_config.py
+++ b/python/lsst/ts/watcher/rules/test/no_config.py
@@ -34,6 +34,8 @@ class NoConfig(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Raises
     ------
@@ -47,8 +49,10 @@ class NoConfig(watcher.BaseRule):
     The alarm name is "test.NoConfig".
     """
 
-    def __init__(self, config):
-        super().__init__(config=config, name="test.NoConfig", remote_info_list=[])
+    def __init__(self, config, log=None):
+        super().__init__(
+            config=config, name="test.NoConfig", remote_info_list=[], log=log
+        )
 
     @classmethod
     def get_schema(cls):

--- a/python/lsst/ts/watcher/rules/test/triggered_severities.py
+++ b/python/lsst/ts/watcher/rules/test/triggered_severities.py
@@ -42,6 +42,8 @@ class TriggeredSeverities(watcher.BaseRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Raises
     ------
@@ -64,11 +66,12 @@ class TriggeredSeverities(watcher.BaseRule):
     The alarm name is ``f"test.TriggeredSeverities.{config.name}"``
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         super().__init__(
             config=config,
             name=f"test.TriggeredSeverities.{config.name}",
             remote_info_list=[],
+            log=log,
         )
         self.run_task = utils.make_done_future()
         self.trigger_next_severity_event = asyncio.Event()

--- a/python/lsst/ts/watcher/rules/under_pressure.py
+++ b/python/lsst/ts/watcher/rules/under_pressure.py
@@ -35,6 +35,8 @@ class UnderPressure(BaseEssRule):
     ----------
     config : `types.SimpleNamespace`
         Rule configuration, as validated by the schema.
+    log : `logging.Logger`, optional
+        Parent logger.
 
     Notes
     -----
@@ -47,7 +49,7 @@ class UnderPressure(BaseEssRule):
     where the data is differentiated by the value of the sensorName field.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log=None):
         super().__init__(
             config=config,
             name=f"UnderPressure.{config.name}",
@@ -58,6 +60,7 @@ class UnderPressure(BaseEssRule):
             big_is_bad=False,
             units="Pa",
             value_format="0.2f",
+            log=log,
         )
 
     @classmethod

--- a/python/lsst/ts/watcher/watcher_csc.py
+++ b/python/lsst/ts/watcher/watcher_csc.py
@@ -106,7 +106,10 @@ class WatcherCsc(salobj.ConfigurableCsc):
             self.model = None
 
         self.model = Model(
-            domain=self.domain, config=config, alarm_callback=self.output_alarm
+            domain=self.domain,
+            config=config,
+            alarm_callback=self.output_alarm,
+            log=self.log,
         )
         if config.escalation_url:
             try:

--- a/tests/rules/test_enabled.py
+++ b/tests/rules/test_enabled.py
@@ -123,6 +123,12 @@ class EnabledTestCase(unittest.IsolatedAsyncioTestCase):
             async with watcher.Model(
                 domain=controller.domain, config=watcher_config
             ) as model:
+                await controller.evt_summaryState.set_write(
+                    summaryState=salobj.State.OFFLINE, force_output=True
+                )
+
+                await asyncio.sleep(STD_TIMEOUT)
+
                 await model.enable()
 
                 assert len(model.rules) == 1

--- a/tests/test_topic_callback.py
+++ b/tests/test_topic_callback.py
@@ -165,6 +165,10 @@ class TopicCallbackTestCase(unittest.IsolatedAsyncioTestCase):
             readonly=True,
             include=["summaryState"],
         ) as remote:
+            await controller.evt_summaryState.set_write(
+                summaryState=salobj.State.ENABLED, force_output=True
+            )
+            await asyncio.sleep(STD_TIMEOUT)
             topic_callback = watcher.TopicCallback(
                 topic=remote.evt_summaryState, rule=bad_rule, model=model
             )


### PR DESCRIPTION
In addition to fixing the bug with the heartbeat alarm I also made some general improvements to the unit tests reliability with salobj-kafka.