### PR TITLE
Tickets/dm 50911

### DIFF
--- a/doc/alarm_list.rst
+++ b/doc/alarm_list.rst
@@ -1,0 +1,11 @@
+.. _alarm-list:
+
+List of Watcher Alarms
+======================
+
+This page provides a comprehensive list of all available alarms in the Watcher CSC. Each alarm is designed to monitor specific conditions and trigger alerts when those conditions are met.
+
+.. automodapi:: lsst.ts.watcher.rules
+   :no-main-docstr:
+
+For more detailed information about each alarm's implementation, configuration options, and behavior, please refer to the linked API documentation.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,6 +6,12 @@
 lsst.ts.Watcher
 ###############
 
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   alarm_list
+
 .. image:: https://img.shields.io/badge/Project Metadata-gray.svg
     :target: https://ts-xml.lsst.io/index.html#index-csc-table-watcher
 .. image:: https://img.shields.io/badge/SAL\ Interface-gray.svg
@@ -133,6 +139,11 @@ An alarm will be automatically acknowledged only if its current severity stays N
 
 An alarm will be automatically unacknowledged only if the condition does not get worse than the level at which it was ackowledged,
 and does not get resolved (go to NONE), during the full ``auto_unacknowledge_delay`` period after being acknowledged.
+
+List of Watcher Alarms
+======================
+
+* :doc:`View the complete list of Watcher alarms <alarm_list>`
 
 SquadCast Notes
 ===============

--- a/doc/news/DM-50911.bugfix.rst
+++ b/doc/news/DM-50911.bugfix.rst
@@ -1,0 +1,1 @@
+Remove warnings from document generation.

--- a/doc/news/DM-50911.feature.rst
+++ b/doc/news/DM-50911.feature.rst
@@ -1,0 +1,1 @@
+Add alarm list to documentation.

--- a/python/lsst/ts/watcher/alarm.py
+++ b/python/lsst/ts/watcher/alarm.py
@@ -57,7 +57,7 @@ class Alarm:
         acknowledged. Never if 0 (the default).
     auto_unacknowledge_delay : `float`
         The delay (seconds) after which an alarm will be automatically
-        unacknowleddged. Never if 0 (the default).
+        unacknowledged. Never if 0 (the default).
     do_escalate : `bool`
         Should the alarm be escalated? The value is set by this class
         and is intended to be read by the alarm callback.
@@ -225,17 +225,17 @@ class Alarm:
         self._cancel_unmute()
 
     async def make_log_entry(self, log_server_url):
-        """Post message to narrative log entry in response to alarm
+        """Post message to narrative log entry in response to alarm.
+
         Parameters
         ----------
-        log_server_url: `str`
+        log_server_url : `str`
             URL of the narrativelog service.
 
         Returns
         -------
-        response: `dict`
-           JSON respose from Post
-
+        response : `dict`
+            JSON response from Post.
         """
         alarm_severity_level = {
             AlarmSeverity.NONE: logging.DEBUG,


### PR DESCRIPTION
Watcher alarm list documentation.

It uses the existing `automodapi` directive already in `developer_guide.rst`, which automatically generates documentation for all the classes in the `lsst.ts.watcher.rules` module. It essentially creates a list of alarms with descriptions pulled directly from their docstrings.

.. automodapi:: lsst.ts.watcher.rules

Example:
https://ts-watcher.lsst.io/builds/361/index.html#list-of-watcher-alarms
